### PR TITLE
Spaces in string is removed

### DIFF
--- a/ObjC2RubyMotion.py
+++ b/ObjC2RubyMotion.py
@@ -7,10 +7,12 @@ class CodeConverter(object):
     def result(self):
         self.multilines_to_one_line()
         self.replace_nsstring()
+        self.mark_spaces_in_string()
         self.convert_square_brackets_expression()
         self.remove_semicolon_at_the_end()
         self.remove_autorelease()
         self.remove_type_declaration()
+        self.restore_spaces_in_string()
         return self.s
 
     # Helpers
@@ -25,6 +27,9 @@ class CodeConverter(object):
         msg = re.sub(r'([^:]+)\:\s*(.+)', self.convert_args, matchobj.group(2))
         return "%s.%s" % (matchobj.group(1), msg)
 
+    def space_to_mark(self, matchobj):
+        return re.sub(r' ', '__SPACE__', matchobj.group(1))
+
     # Conversions
     def multilines_to_one_line(self):
         # Remove trailing white space first. Refs: TrimTrailingWhiteSpace
@@ -35,6 +40,13 @@ class CodeConverter(object):
     def replace_nsstring(self):
         self.s = re.sub(r'@("(?:[^\\"]|\\.)*")', r'\1', self.s)
         return self
+
+    def mark_spaces_in_string(self):
+        self.s = re.sub(r'("(?:[^\\"]|\\.)*")', self.space_to_mark, self.s)
+        return self
+
+    def restore_spaces_in_string(self):
+        self.s = re.sub(r'__SPACE__', ' ', self.s)
 
     def convert_square_brackets_expression(self):
         max_attempt = 10 # Avoid infinite loops

--- a/ObjC2RubyMotion.py
+++ b/ObjC2RubyMotion.py
@@ -16,9 +16,9 @@ class CodeConverter(object):
     # Helpers
     def convert_args(self, matchobj):
         # Consider args with colon followed by spaces
-        following_args = re.sub(r'([^:]+)(\s+)', r'\1,', matchobj.group(2))
-        # Clear extra spaces
-        following_args = re.sub(r'\s+', '', following_args)
+        following_args = re.sub(r'([^:]+)(\s+)(\S+):', r'\1,\3:', matchobj.group(2))
+        # Clear extra spaces after colons
+        following_args = re.sub(r':\s+', ':', following_args)
         return "%s(%s)" % (matchobj.group(1), following_args)
 
     def ruby_style_code(self, matchobj):

--- a/test_replace.py
+++ b/test_replace.py
@@ -92,7 +92,7 @@ class ObjcToRubyMotion(unittest.TestCase):
                                                              cancelButtonTitle:@"OK"
                                                              otherButtonTitles:nil] autorelease];
                       [alert show]"""
-        expected = """alert = UIAlertView.alloc.initWithTitle("Warning",message:"toomanyalerts",delegate:nil,cancelButtonTitle:"OK",otherButtonTitles:nil)
+        expected = """alert = UIAlertView.alloc.initWithTitle("Warning",message:"too many alerts",delegate:nil,cancelButtonTitle:"OK",otherButtonTitles:nil)
                       alert.show"""
         result = CodeConverter(source).result()
         self.assertEqual(result, expected)
@@ -106,5 +106,5 @@ class ObjcToRubyMotion(unittest.TestCase):
     # For Bugfix
     def test_string_including_spaces(self):
         source   = '[[UIAlertView alloc] initWithTitle:@"Warning" message:@"too many alerts"];'
-        expected = 'UIAlertView.alloc.initWithTitle("Warning",message:"too many alerts")'
-        self.assertEqual(CodeConverter(source).convert_square_brackets_expression().s, expected)
+        expected = 'UIAlertView.alloc.initWithTitle("Warning",message:"too many alerts");'
+        self.assertEqual(CodeConverter(source).replace_nsstring().convert_square_brackets_expression().s, expected)

--- a/test_replace.py
+++ b/test_replace.py
@@ -102,3 +102,9 @@ class ObjcToRubyMotion(unittest.TestCase):
         source   = 'UIWindow* aWindow = [[[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]] autorelease];'
         expected = 'aWindow = UIWindow.alloc.initWithFrame(UIScreen.mainScreen.bounds)'
         self.assertEqual(CodeConverter(source).result(), expected)
+
+    # For Bugfix
+    def test_string_including_spaces(self):
+        source   = '[[UIAlertView alloc] initWithTitle:@"Warning" message:@"too many alerts"];'
+        expected = 'UIAlertView.alloc.initWithTitle("Warning",message:"too many alerts")'
+        self.assertEqual(CodeConverter(source).convert_square_brackets_expression().s, expected)

--- a/test_replace.py
+++ b/test_replace.py
@@ -105,6 +105,6 @@ class ObjcToRubyMotion(unittest.TestCase):
 
     # For Bugfix
     def test_string_including_spaces(self):
-        source   = '[[UIAlertView alloc] initWithTitle:@"Warning" message:@"too many alerts"];'
-        expected = 'UIAlertView.alloc.initWithTitle("Warning",message:"too many alerts");'
+        source   = '[[UIAlertView alloc] initWithTitle:@"Warning" message:@"  too many alerts!  \"  "];'
+        expected = 'UIAlertView.alloc.initWithTitle("Warning",message:"  too many alerts!  \"  ");'
         self.assertEqual(CodeConverter(source).replace_nsstring().convert_square_brackets_expression().s, expected)


### PR DESCRIPTION
`[[UIAlertView alloc] initWithTitle:@"Warning" message:@"too many alerts"];`
will be
`UIAlertView.alloc.initWithTitle("Warning",message:"toomany,alerts")`
should be
`UIAlertView.alloc.initWithTitle("Warning",message:"too many alerts")`

CRITICAL

created test for it on `spaces_in_string` branch
